### PR TITLE
override of equals method to delegate this functionality to the equal…

### DIFF
--- a/impl/src/main/java/javax/faces/model/SelectItem.java
+++ b/impl/src/main/java/javax/faces/model/SelectItem.java
@@ -368,7 +368,11 @@ public class SelectItem implements Serializable {
     public void setNoSelectionOption(boolean noSelectionOption) {
         this.noSelectionOption = noSelectionOption;
     }
-
+    
+    @Override
+    public boolean equals(Object obj) {
+        return this.getValue().equals(obj.getValue());
+    }
 
 
 }


### PR DESCRIPTION
…s method of value object

Validation Error: Value is not valid, this error is raising due to a bad implementation of object equals method