### PR TITLE
Fixes #4386 - ELFlash sometimes throws ArrayIndexOutOfBoundsException if cookie contains invalid values

### DIFF
--- a/jsf-ri/src/main/java/com/sun/faces/util/ByteArrayGuardAESCTR.java
+++ b/jsf-ri/src/main/java/com/sun/faces/util/ByteArrayGuardAESCTR.java
@@ -149,11 +149,16 @@ public final class ByteArrayGuardAESCTR {
     }
 
     public String decrypt(String value) throws InvalidKeyException {
-        
-        byte[] bytes = DatatypeConverter.parseBase64Binary(value);;
-        
+
+        byte[] bytes = DatatypeConverter.parseBase64Binary(value);
+
         try {
             byte[] iv = new byte[16];
+
+            if (bytes.length < iv.length) {
+                throw new InvalidKeyException("Invalid characters in decrypted value");
+            }
+
             System.arraycopy(bytes, 0, iv, 0, iv.length);
             IvParameterSpec ivspec = new IvParameterSpec(iv);
 

--- a/test/unit/src/test/java/com/sun/faces/util/ByteArrayGuardAESCTRTest.java
+++ b/test/unit/src/test/java/com/sun/faces/util/ByteArrayGuardAESCTRTest.java
@@ -39,6 +39,8 @@
  */
 package com.sun.faces.util;
 
+import java.security.InvalidKeyException;
+import javax.xml.bind.DatatypeConverter;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
@@ -60,6 +62,17 @@ public class ByteArrayGuardAESCTRTest {
         assertEquals(decryptedValue, value);
 
         
+    }
+
+    @Test(expected = InvalidKeyException.class)
+    public void testDecryptValueWithoutIvBytes() throws InvalidKeyException {
+        ByteArrayGuardAESCTR sut = new ByteArrayGuardAESCTR();
+        
+        String value = "noIV";
+        byte[] bytes = DatatypeConverter.parseBase64Binary(value);
+        assertTrue(bytes.length < 16);
+
+        sut.decrypt(value);
     }
     
 }


### PR DESCRIPTION
- Fixes #4386
- Fixes #4402 